### PR TITLE
Add Blob Delete Options

### DIFF
--- a/src/methods-azure.ts
+++ b/src/methods-azure.ts
@@ -135,7 +135,4 @@ export async function UploadToAzure(
 
     core.info(`Uploaded ${localFilePath} to ${containerName}/${finalPath}...`);
   });
-
-
 }
-


### PR DESCRIPTION
This update should fix #113 the changes are

- Await the `delete()` promise
- Pass a `BlobDeleteOptions` parameter with `DeleteSnapshotsOptionType = "include"`