### PR TITLE
Add repo devcontainer for Node 24 development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "Action-AzureBlobUpload (Node 24)",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm",
+  "remoteUser": "node",
+  "containerEnv": {
+    "NODE_OPTIONS": "--max_old_space_size=4096"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "github.vscode-github-actions",
+        "vitest.explorer"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "eslint.validate": [
+          "javascript",
+          "typescript"
+        ]
+      }
+    }
+  },
+  "postCreateCommand": "npm ci",
+  "postStartCommand": "npm run build"
+}


### PR DESCRIPTION
This adds a repository devcontainer so Codespaces and local Dev Containers start with the toolchain this action already expects in CI.

## What changed
- Added `.devcontainer/devcontainer.json` using the Node 24 devcontainer image.
- Set `NODE_OPTIONS=--max_old_space_size=4096` to match CI runtime behavior.
- Added `postCreateCommand: npm ci` for reproducible dependency install from lockfile.
- Added `postStartCommand: npm run build` so generated `lib/` output is available immediately.
- Added VS Code extensions/settings for this repo's workflow: ESLint, Prettier, GitHub Actions, and Vitest.

## Notes for reviewers
This is intentionally config-only and does not change action runtime behavior. It only standardizes the development environment for contributors and Codespaces.